### PR TITLE
Swapped icon values to fix having a blank icon.

### DIFF
--- a/apps/system/components/url_edit.js
+++ b/apps/system/components/url_edit.js
@@ -212,7 +212,7 @@ class PlacesItem extends HTMLElement {
       `;
 
     let icon = shadow.querySelector("img");
-    icon.src = this.variant("icon") || content.icon;
+    icon.src = content.icon || this.variant("icon");
 
     this.onclick = () => {
       this.dispatchEvent(


### PR DESCRIPTION
before: it loads a blank image no matter what icon the list item has
after: now looks like the homescreen search list item. with a working icon