### PR TITLE
[system] Save the screen brightness to the settings database.

### DIFF
--- a/apps/system/js/power_manager.js
+++ b/apps/system/js/power_manager.js
@@ -44,8 +44,9 @@ class PowerManagerService {
     this.locked = false;
     this._ready = new Promise((resolve, reject) => {
       window.apiDaemon.getPowerManager().then(
-        (service) => {
+        async (service) => {
           this.service = service;
+          await this.initBrightness();
           resolve();
         },
         (error) => {
@@ -165,9 +166,19 @@ class PowerManagerService {
     });
   }
 
+  // Initializes the screen brightness setting for the service.
+  async initBrightness() {
+    this._settings = await apiDaemon.getSettings();
+    try {
+      const result = await this._settings.get("display.brightness");
+      this._currentBrighness = result.value;
+    } catch (e) {}
+  }
+
   set brightness(value) {
     if (this.service) {
       this.service.screenBrightness = value;
+      this._settings.set([{ name: "display.brightness", value }]);
     }
   }
 

--- a/defaults/default-settings.json
+++ b/defaults/default-settings.json
@@ -1,4 +1,5 @@
 {
+  "display.brightness": 80,
   "ums.enabled": false,
   "ums.volume.external.enabled": true,
   "ums.volume.extsdcard.enabled": true,


### PR DESCRIPTION
This PR implements saving the screen brightness to the settings database and restoring the brightness value on boot. However, there is an issue: I'm not sure if `display.brightness` is the appropriate key or if there is another defined key for saving screen brightness data. If there is, please let me know so I can make the necessary changes.