### PR TITLE
Add package deps (Fixes #68)

### DIFF
--- a/builder/src/templates/debian/control
+++ b/builder/src/templates/debian/control
@@ -1,5 +1,6 @@
 Package: ${PKG_NAME}
 Version: ${VERSION}-${RELEASE_NUMBER}
+Depends: libgtk-3-0 (>= 3.0.0), libasound2 (>= 1.0.16), libdbus-glib-1-2 (>= 0.78), fonts-arphic-ukai, fonts-arphic-uming, sway, network-manager
 Maintainer: Fabrice Desré <fabrice@capyloon.org>
 Section: misc
 Priority: optional


### PR DESCRIPTION
Add 'Depends' line to warn about install dependencies.  

Test results
--------------------
 dpkg -I /home/arky/Code/Capyloon/nutria/builder/output/debian/capyloon-rpi_0.3-19545_arm64.deb 
 new Debian package, version 2.0.
 size 76850188 bytes: control archive=620 bytes.
     343 bytes,     9 lines      control              
     175 bytes,     7 lines   *  postinst             #!/bin/sh
     108 bytes,     4 lines   *  preinst              #!/bin/sh
     175 bytes,     7 lines   *  prerm                #!/bin/sh
 Package: capyloon-rpi
 Version: 0.3-19545
 Depends: libgtk-3-0 (>= 3.0.0), libasound2 (>= 1.0.16), libdbus-glib-1-2 (>= 0.78), fonts-arphic-ukai, fonts-arphic-uming, sway, network-manager
 Maintainer: Fabrice Desré <fabrice@capyloon.org>
 Section: misc
 Priority: optional
 Standards-Version: 0.1
 Description: Reclaim Your Web!
 Architecture: arm64
$ dpkg -I /home/arky/Code/Capyloon/nutria/builder/output/debian/capyloon-desktop_0.3-19545_amd64.deb 
 new Debian package, version 2.0.
 size 153711644 bytes: control archive=624 bytes.
     347 bytes,     9 lines      control              
     175 bytes,     7 lines   *  postinst             #!/bin/sh
     108 bytes,     4 lines   *  preinst              #!/bin/sh
     175 bytes,     7 lines   *  prerm                #!/bin/sh
 Package: capyloon-desktop
 Version: 0.3-19545
 Depends: libgtk-3-0 (>= 3.0.0), libasound2 (>= 1.0.16), libdbus-glib-1-2 (>= 0.78), fonts-arphic-ukai, fonts-arphic-uming, sway, network-manager
 Maintainer: Fabrice Desré <fabrice@capyloon.org>
 Section: misc
 Priority: optional
 Standards-Version: 0.1
 Description: Reclaim Your Web!
 Architecture: amd64

$ dpkg -I /home/arky/Code/Capyloon/nutria/builder/output/debian/capyloon-rpi_0.3-19545_arm64.deb 
 new Debian package, version 2.0.
 size 76850188 bytes: control archive=620 bytes.
     343 bytes,     9 lines      control              
     175 bytes,     7 lines   *  postinst             #!/bin/sh
     108 bytes,     4 lines   *  preinst              #!/bin/sh
     175 bytes,     7 lines   *  prerm                #!/bin/sh
 Package: capyloon-rpi
 Version: 0.3-19545
 Depends: libgtk-3-0 (>= 3.0.0), libasound2 (>= 1.0.16), libdbus-glib-1-2 (>= 0.78), fonts-arphic-ukai, fonts-arphic-uming, sway, network-manager
 Maintainer: Fabrice Desré <fabrice@capyloon.org>
 Section: misc
 Priority: optional
 Standards-Version: 0.1
 Description: Reclaim Your Web!
 Architecture: arm64

$ sudo dpkg -i ./nutria/builder/output/debian/capyloon-desktop_0.3-19545_amd64.deb 
(Reading database ... 807396 files and directories currently installed.)
sPreparing to unpack .../capyloon-desktop_0.3-19545_amd64.deb ...
Unpacking capyloon-desktop (0.3-19545) over (0.3-19545) ...
dpkg: dependency problems prevent configuration of capyloon-desktop:
 capyloon-desktop depends on fonts-arphic-ukai; however:
  Package fonts-arphic-ukai is not installed.
 capyloon-desktop depends on fonts-arphic-uming; however:
  Package fonts-arphic-uming is not installed.
 capyloon-desktop depends on sway; however:
  Package sway is not installed.

dpkg: error processing package capyloon-desktop (--install):
 dependency problems - leaving unconfigured
Processing triggers for bamfdaemon (0.5.6+22.04.20220217-0ubuntu1) ...
Rebuilding /usr/share/applications/bamf-2.index...
Processing triggers for mailcap (3.70+nmu1ubuntu1) ...
Processing triggers for gnome-menus (3.36.0-1ubuntu3) ...
Processing triggers for desktop-file-utils (0.26-1ubuntu3) ...
Processing triggers for hicolor-icon-theme (0.17-2) ...
Errors were encountered while processing:
 capyloon-desktop


