### PR TITLE
[README] Fix subtle typos and grammer

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ SUBCOMMANDS:
 
 ## The `clean` command
 
-This removes all build artifacts from the selected output directory. Note that this includes all data from development and production profiles.
+This removes all build artefacts from the selected output directory. Note that this includes all data from development and production profiles.
 
 ## The `deb` command
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ SUBCOMMANDS:
 `jackady` also relies on some environment variables to be set to control its behavior:
 | Variable | Description | Default value |
 | ------------------------ | ----------------------------------------------------------------------------------------------- | ------------------------------------------ |
-| NUTRIA_OUPUT_ROOT | The path where build artefacts are created. | `./builder/output` |
+| NUTRIA_OUTPUT_ROOT | The path where build artifacts are created. | `./builder/output` |
 | NUTRIA_API_DAEMON_ROOT | The path to a checkout of the [`api-daemon` crate](https://github.com/capyloon/api-daemon). | |
 | NUTRIA_API_DAEMON_BINARY | The path to the `api-daemon` executable built for the desktop platform. | `./prebuilts/${HOST_TARGET}/api-daemon` |
 | NUTRIA_API_DAEMON_PORT | The port on which the api-daemon should run. | 80 but needs to be set to 8081 on desktop. |
@@ -75,19 +75,19 @@ SUBCOMMANDS:
 | NUTRIA_B2G_BINARY | The path to the b2g binary used for running on desktop. | `./b2g` |
 | NUTRIA_B2G_PACKAGE | The path to a b2g package that will be pushed to a device. | |
 | NUTRIA_PREBUILTS_JSON | The path to a json file describing where to find prebuilts artifacts. | |
-| NUTRIA_LINUX_USER | The user name to use when connecting to a remote Linux device. | mobian |
+| NUTRIA_LINUX_USER | The username to use when connecting to a remote Linux device. | mobian |
 | NUTRIA_LINUX_HOST | The hostname or ip of the remote Linux device | pinephone |
 | NUTRIA_LINUX_DISABLED | Set this variable to any value to disable detection of Linux devices. | |
 
 ## The `clean` command
 
-This removes all build artefacts from the selected output directory. Note that this includes all data from development and production profiles.
+This removes all build artifacts from the selected output directory. Note that this includes all data from development and production profiles.
 
 ## The `deb` command
 
-This will create a debian package under `NUTRIA_OUPUT_ROOT/debian/`.
+This will create a debian package under `NUTRIA_OUTPUT_ROOT/debian/`.
 
-This package provides the desktop session, as well as the mobile & desktop emulators. Note that when installed from the debian package, they all share the same profile data.
+This package provides the desktop session, as well as the mobile & desktop simulators. Note that when installed from the debian package, they all share the same profile data.
 
 The following options are supported:
 
@@ -104,7 +104,7 @@ OPTIONS:
 
 ## The `dev` command
 
-This command runs the desktop emulator in development mode: apps are not packaged, and changes done to them in the `NUTRIA_APPS_ROOT` directory are immediately visible when reloading the apps. Changes to the system app still require a full restart.
+This command runs the desktop simulator in development mode: apps are not packaged, and changes done to them in the `NUTRIA_APPS_ROOT` directory are immediately visible when reloading the apps. Changes to the system app still require a full restart.
 
 The following options are supported:
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ SUBCOMMANDS:
 `jackady` also relies on some environment variables to be set to control its behavior:
 | Variable | Description | Default value |
 | ------------------------ | ----------------------------------------------------------------------------------------------- | ------------------------------------------ |
-| NUTRIA_OUTPUT_ROOT | The path where build artifacts are created. | `./builder/output` |
+| NUTRIA_OUTPUT_ROOT | The path where build artefacts are created. | `./builder/output` |
 | NUTRIA_API_DAEMON_ROOT | The path to a checkout of the [`api-daemon` crate](https://github.com/capyloon/api-daemon). | |
 | NUTRIA_API_DAEMON_BINARY | The path to the `api-daemon` executable built for the desktop platform. | `./prebuilts/${HOST_TARGET}/api-daemon` |
 | NUTRIA_API_DAEMON_PORT | The port on which the api-daemon should run. | 80 but needs to be set to 8081 on desktop. |


### PR DESCRIPTION
- fixed word typos like:
  - OUPUT => OUTPUT

- used correct terms like simulator. emulators emulate both hardware and software and use virtualization which use a lot of resources, simulator is cross-platform and simulates only the software experience and is lightweight.
- replaced "user name" to "username" due to "username" being commonly used to refer to usernames in devices while "user name" is user to refer to user names in real life.